### PR TITLE
Specify that baseband firmware need to be loaded correctly in IDA first

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ with this and anonymize the vendor in the
 
 ### 0. Using BaseSpec in IDA Pro
 BaseSpec contains python scripts based on IDA Pro APIs (IDAPython). To use
-BaseSpec, first load `load_ida.py` as a script file in IDA Pro (using Alt+F7).
+BaseSpec, first load the firmware into IDA at the correct locations, which
+may require parsing of vendor-specific firmware file formats.
+Then, import `load_ida.py` as a script file in IDA Pro (using Alt+F7).
 
 
 ### 1. Preprocessing

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ with this and anonymize the vendor in the
 
 ### 0. Using BaseSpec in IDA Pro
 BaseSpec contains python scripts based on IDA Pro APIs (IDAPython). To use
-BaseSpec, first load the firmware into IDA at the correct locations, which
-may require parsing of vendor-specific firmware file formats.
+BaseSpec, first load the baseband firmware of interest into IDA Pro at the
+correct locations, which may require parsing of vendor-specific firmware
+file formats.
 Then, import `load_ida.py` as a script file in IDA Pro (using Alt+F7).
 
 


### PR DESCRIPTION
As of now, BaseSpec's scatterload-functionality only works correctly when the binary is loaded at the right locations. 
If not loaded correctly, the scatter tables and functions are found, however, the `how` functions in the scatterload-table are not, as they are at different offset, resulting into the script terminating without emulating scatterload.

This PR includes a change to README.md, making this dependency of correct "stage-1" load for the firmware image explicit - alongside with the information, that this require vendor-specific information.